### PR TITLE
Revert "mac build fix"

### DIFF
--- a/miopengemm/CMakeLists.txt
+++ b/miopengemm/CMakeLists.txt
@@ -22,7 +22,6 @@ target_link_libraries(miopengemm ${OPENCL_LIBRARIES})
 
 target_include_directories (miopengemm PUBLIC 
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/dev_include>
-    ${OPENCL_INCLUDE_DIRS}/Headers
     ${OPENCL_INCLUDE_DIRS})
 
 rocm_install_targets(

--- a/miopengemm/include/miopengemm/architests.hpp
+++ b/miopengemm/include/miopengemm/architests.hpp
@@ -4,11 +4,7 @@
 #ifndef GUARD_MIOPENGEMM_ARCHITESTS_HPP
 #define GUARD_MIOPENGEMM_ARCHITESTS_HPP
 
-#if __APPLE__
-#include <opencl.h>
-#else
 #include <CL/cl.h>
-#endif
 #include <miopengemm/derivedparams.hpp>
 #include <miopengemm/hyperparams.hpp>
 

--- a/miopengemm/include/miopengemm/kernel.hpp
+++ b/miopengemm/include/miopengemm/kernel.hpp
@@ -4,11 +4,7 @@
 #ifndef GUARD_MIOPENGEMM_KERNEL_HPP
 #define GUARD_MIOPENGEMM_KERNEL_HPP
 
-#if __APPLE__
-#include <opencl.h>
-#else
 #include <CL/cl.h>
-#endif
 #include <algorithm>
 #include <vector>
 #include <miopengemm/kernelstring.hpp>

--- a/miopengemm/include/miopengemm/miogemm.hpp
+++ b/miopengemm/include/miopengemm/miogemm.hpp
@@ -4,11 +4,7 @@
 #ifndef GUARD_MIOPENGEMM_MIOGEMM_HPP
 #define GUARD_MIOPENGEMM_MIOGEMM_HPP
 
-#if __APPLE__
-#include <opencl.h>
-#else
 #include <CL/cl.h>
-#endif
 #include <miopengemm/error.hpp>
 #include <miopengemm/findparams.hpp>
 #include <miopengemm/geometry.hpp>

--- a/miopengemm/include/miopengemm/openclutil.hpp
+++ b/miopengemm/include/miopengemm/openclutil.hpp
@@ -4,11 +4,7 @@
 #ifndef GUARD_MIOPENGEMM_OPENCLUTIL_H
 #define GUARD_MIOPENGEMM_OPENCLUTIL_H
 
-#if __APPLE__
-#include <opencl.h>
-#else
 #include <CL/cl.h>
-#endif
 #include <tuple>
 #include <miopengemm/outputwriter.hpp>
 

--- a/miopengemm/src/openclutil.cpp
+++ b/miopengemm/src/openclutil.cpp
@@ -1,11 +1,7 @@
 /*******************************************************************************
  * Copyright (C) 2017 Advanced Micro Devices, Inc. All rights reserved. 
  *******************************************************************************/
-#if __APPLE__
-#include <opencl.h>
-#else
 #include <CL/cl.h>
-#endif
 #include <map>
 #include <sstream>
 #include <string>

--- a/miopengemm/src/redirection.cpp
+++ b/miopengemm/src/redirection.cpp
@@ -1,11 +1,7 @@
 /*******************************************************************************
  * Copyright (C) 2017 Advanced Micro Devices, Inc. All rights reserved. 
  *******************************************************************************/
-#if __APPLE__
-#include <opencl.h>
-#else
 #include <CL/cl.h>
-#endif
 #include <algorithm>
 #include <iostream>
 #include <miopengemm/error.hpp>


### PR DESCRIPTION
Reverts ROCmSoftwarePlatform/MIOpenGEMM#5, as this breaks the build.