### PR TITLE
fixed an issue in the NormalFormGenerator that causes undefined variable

### DIFF
--- a/miopengemm/src/normalformgenerator.cpp
+++ b/miopengemm/src/normalformgenerator.cpp
@@ -86,7 +86,8 @@ class NormalFormGenerator : public prepgen::PrepGenerator
     ss << "{"
        << "\n/* setting up where this thread works */\n"
        << "TINT" << Mem::M().name[emat_x] << " group_id = get_group_id(0);\n"
-       << "TINT" << Mem::M().name[emat_x] << " micro_id = (TINT)(get_local_id(0));\n"
+       << "TINT" << Mem::M().name[emat_x] << " micro_id = (TINT" << Mem::M().name[emat_x]
+       << ")(get_local_id(0));\n"
        << "\n"
        << "TINT" << Mem::M().name[emat_x]
        << " macro_id_pll_unroll = group_id % N_MACRO_TILES_PLL_UNROLL;\n"


### PR DESCRIPTION
I got the following error in smallgeometrytests if there is no kernel_cache (i.e., removing all cache*.cachetxt in init_kernel_cache). The error is caused by the undefined variable in the kernel generated by NormalFormGenerator.

test 1/32
tC0_tA0_tB0_colMaj0_m81_n71_k58_lda67_ldb81_ldc83_ws1000000_f32
Found device gfx900 @{[64 CUs] [1600 MHz]}. Use/modify a CLHint to change.

Entering new descent.
{0.05 <<< @t=2.723e-05[s] <<< 0.1} {0 <<< @i=0 <<< 100000}
geometry : tC0_tA0_tB0_colMaj0_m81_n71_k58_lda67_ldb81_ldc83_ws1000000_f32
allotted time : 0.1
Warmstart requested [@ rank 0] #trials to find viable hp in graph : 7 (0.362938 [ms])
No kernel cache match found, returning random valid.
Time in get_default : 0.00107182 [s]

[1, 0.00s] "MIC8_PAD2_PLU0_LIW1_MIW0_WOS0_VEW1", "MIC6_PAD2_PLU1_LIW0_MIW0_WOS2_VEW1", "UNR32_GAL2_PUN1_ICE1_IWI1_SZT0_MAD0_NAW16_UFO0_MAC32_SKW11_AFI1_MIA1"
compiling WSB. /tmp/AMD_1115_19/t_1115_21.cl:51:21: error: use of undeclared identifier 'TINT'
TINTB micro_id = (TINT)(get_local_id(0));
^
1 error generated.
Failed in 0.010 [s]
terminate called after throwing an instance of 'MIOpenGEMM::miog_error'
what():