### PR TITLE
increased search threshold for large database

### DIFF
--- a/miopengemm/src/tinyzero.cpp
+++ b/miopengemm/src/tinyzero.cpp
@@ -357,7 +357,7 @@ Solution TinyZero::find0(const Constraints& constraints, const FindParams& fparm
     // 0, 1, 5, 10, 15, etc
     warmstart = (ftrack.get_descents() < 2 || ftrack.get_descents() % 5 == 0) ? true : false;
 
-    double allotted_sd = std::max(0.1, fparms.hl_outer.max_time - ftrack.get_elapsed());
+    double allotted_sd = std::max(1.0, fparms.hl_outer.max_time - ftrack.get_elapsed());
 
     auto soln = single_descent_find(
       allotted_sd, constraints, fparms.hl_core, ftrack, fparms.sumstat, warmstart, warmstart_rank);
@@ -637,7 +637,8 @@ Solution TinyZero::single_descent_find(double             allotted_time,
 
   if (timer.get_elapsed() >= allotted_time)
   {
-    mowri << "stopping the search because allotted time has been surpassed" << Endl;
+    mowri << "stopping the search because allotted time has been surpassed: " << timer.get_elapsed()
+          << " > " << allotted_time << Endl;
   }
 
   else if (improvement_found_on_front == false)


### PR DESCRIPTION
I got the following Jenkins failure for large search time with a large database. Thus, I increased the allotted time threshold.

test 10/32
<float>  tC0_tA0_tB0_colMaj1_m81_n91_k67_lda90_ldb77_ldc93_ws1000000_f32
Found device gfx900 @{[64 CUs]  [1500 MHz]}.  Use/modify a CLHint to change.

Entering new descent. 
{0.05 <<< @t=3.009e-06[s] <<< 0.1}   {0 <<< @i=0 <<< 100000}   
geometry : tC0_tA0_tB0_colMaj1_m81_n91_k67_lda90_ldb77_ldc93_ws1000000_f32
allotted time : 0.100000
Warmstart requested [@ rank 0]  Nearest match in kernel cache:
device       :   `gfx803'
constraints  :   `'
geometry     :   `tC0_tA0_tB0_colMaj1_m77_n77_k77_lda77_ldb77_ldc77_ws0_f32'
Time in get_default : 0.099062 [s]
stopping the search because allotted time has been surpassed
terminate called after throwing an instance of 'MIOpenGEMM::miog_error'
  what():  