### PR TITLE
Fix underlinked shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,10 @@ endif()
 set( CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel." )
 find_package( OpenCL REQUIRED )
 
+SET(CMAKE_THREAD_PREFER_PTHREAD TRUE)
+SET(THREADS_PREFER_PTHREAD_FLAG TRUE)
+find_package(Threads REQUIRED)
+
 #SET (CMAKE_CXX_COMPILER "clang++")
 
 include(EnableCompilerWarnings)

--- a/miopengemm/CMakeLists.txt
+++ b/miopengemm/CMakeLists.txt
@@ -14,7 +14,10 @@ file(GLOB_RECURSE source_files src/*.cpp)
 
 add_library(miopengemm ${source_files})
 
-target_link_libraries(miopengemm ${OPENCL_LIBRARIES} ${OpenBLAS_LIB} ${CLBLAST_LIB} ${ISAAC_LIB})
+target_link_libraries(miopengemm
+    PUBLIC ${OPENCL_LIBRARIES} ${OpenBLAS_LIB} ${CLBLAST_LIB} ${ISAAC_LIB}
+    PRIVATE ${CMAKE_THREAD_LIBS_INIT}
+)
 
 target_include_directories (miopengemm PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/dev_include>)
 target_include_directories (miopengemm SYSTEM PUBLIC 

--- a/miopengemm/include/miopengemm/tinyzero.hpp
+++ b/miopengemm/include/miopengemm/tinyzero.hpp
@@ -10,7 +10,6 @@
 #include <limits>
 #include <map>
 #include <sstream>
-#include <thread>
 #include <tuple>
 #include <vector>
 #include <miopengemm/architests.hpp>

--- a/miopengemm/src/kernelcachemerge.cpp
+++ b/miopengemm/src/kernelcachemerge.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <chrono>
 #include <functional>
+#include <thread>
 #include <unordered_map>
 #include <miopengemm/kernelcachemerge.hpp>
 #include <miopengemm/setabcw.hpp>


### PR DESCRIPTION
libmiopengemm.so uses symbols from libpthread, but doesn't explicitly link to it

```
sclarkson@localhost:~/miopengemm$ nm -D /opt/rocm/miopengemm/lib/libmiopengemm.so | grep pthread
                 U pthread_create
                 w pthread_equal
                 w __pthread_key_create
                 w pthread_mutex_lock
                 w pthread_mutex_unlock
                 w pthread_once
sclarkson@localhost:~/miopengemm$ objdump -p /opt/rocm/miopengemm/lib/libmiopengemm.so | grep NEEDED
  NEEDED               libOpenCL.so.1
  NEEDED               libstdc++.so.6
  NEEDED               libm.so.6
  NEEDED               libgcc_s.so.1
  NEEDED               libc.so.6
  NEEDED               ld-linux-x86-64.so.2
```

This forces any user of the library to explicitly link to libpthread themselves, despite not using threads directly. For example

```
sclarkson@localhost:~/miopengemm$ g++ -std=c++11 examples/bench.cpp -I/opt/rocm/include -L/opt/rocm/lib -lmiopengemm
/opt/rocm/lib/libmiopengemm.so: undefined reference to `pthread_create'
collect2: error: ld returned 1 exit status
```

The linking was made private and headers modified to make it clear that threading isn't needed in the public interface. (Those other libraries should also probably be private).

One of the tests explicitly uses threads, so the pthread options can't be removed from the tests CMakeLists.txt