### PR TITLE
Don't check (at runtime) if unsigned integers are non-negative

### DIFF
--- a/miopengemm/src/alphagenerator.cpp
+++ b/miopengemm/src/alphagenerator.cpp
@@ -788,7 +788,15 @@ const TSHORT group_id_z = group_id % N_WORK_ITEMS_PER_C_ELM;
       ss << "\n/* branching between work groups : some wgs have 1 more unroll "
             "to process. */\n";
       ss << "int n_unrolls_remaining = (" << dp.k_effective_div_G_UNROLL;
-      ss << ") +  (group_id_z < n_work_groups_with_1_more);";
+      ss << ") ";
+
+     // To avoid the compiler outsmarting us when n_work_groups_with_1_more is zero 
+     // [tautological-unsigned-zero-compare], we avoid checking if unsigned integers
+     // are less than zero. 
+     if (dp.k_effective_mod_G_UNROLL > 0){
+      ss << " +  (group_id_z < n_work_groups_with_1_more)";
+     }
+     ss << ";";
     }
   }
 


### PR DESCRIPTION
The OpenCL compiler (seems to) check if there is a runtime check if an unsigned integer is negative. this fix prevents the kernel generator from emitting this comparison in the kernel, so not allowing the compiler to raise this warning. 

UPD: Expected to fix https://github.com/ROCmSoftwarePlatform/MIOpen/issues/692