### PR TITLE
add include for `numeric_limits`

### DIFF
--- a/miopengemm/src/enums.cpp
+++ b/miopengemm/src/enums.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <array>
 #include <iostream>
+#include <limits>
 #include <numeric>
 #include <miopengemm/enums.hpp>
 #include <miopengemm/outputwriter.hpp>


### PR DESCRIPTION
fixes compilation with GCC 11