### PR TITLE
Remove redundant and hard coded path from install interface

### DIFF
--- a/miopengemm/CMakeLists.txt
+++ b/miopengemm/CMakeLists.txt
@@ -41,7 +41,8 @@ endif()
 
 target_include_directories (miopengemm PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/dev_include>)
 # Opencl headers installed in cmake install includedir and INTERFACE_INCLUDE_DIRECTORIES have that path
-# OPENCL_INCLUDE_DIRS is redundant and not required in config files
+# OPENCL_INCLUDE_DIRS is redundant and not required in install interface.
+# Required for building, so limiting it to build interface
 target_include_directories (miopengemm SYSTEM PUBLIC
 
     $<BUILD_INTERFACE:${OPENCL_INCLUDE_DIRS}>

--- a/miopengemm/CMakeLists.txt
+++ b/miopengemm/CMakeLists.txt
@@ -40,9 +40,11 @@ if(NOT WIN32 AND NOT APPLE)
 endif()
 
 target_include_directories (miopengemm PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/dev_include>)
-target_include_directories (miopengemm SYSTEM PUBLIC 
+# Opencl headers installed in cmake install includedir and INTERFACE_INCLUDE_DIRECTORIES have that path
+# OPENCL_INCLUDE_DIRS is redundant and not required in config files
+target_include_directories (miopengemm SYSTEM PUBLIC
 
-    ${OPENCL_INCLUDE_DIRS} 
+    $<BUILD_INTERFACE:${OPENCL_INCLUDE_DIRS}>
     ${CLBLAST_INCLUDE_DIR}
     ${ISAAC_INCLUDE_DIR}
     ${OpenBLAS_INCLUDE_DIR}
@@ -57,7 +59,7 @@ endif()
 
 rocm_install_targets(
   TARGETS miopengemm
-  INCLUDE 
+  INCLUDE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 


### PR DESCRIPTION
Opencl header files  installed in /opt/rocm-ver/include/CL
Including CMAKE_INSTALL_INCLUDEDIR will help to find the opencl header files as well
OPENCL_INCLUDE_DIRS is coming as hard coded path in config file and having hard coded paths in config files is not recommended, so limited it to BUILD_INTERFACE