### PR TITLE
Remove hard coded path in interface link libraries

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -8,7 +8,7 @@ add_custom_target(examples COMMENT "Build all examples.")
 
 function(add_example_executable EX_NAME)
     add_executable (${EX_NAME} EXCLUDE_FROM_ALL ${ARGN})
-    target_link_libraries(${EX_NAME} miopengemm)
+    target_link_libraries(${EX_NAME} miopengemm ${OPENCL_LIBRARIES})
     add_dependencies(examples ${EX_NAME})
 endfunction(add_example_executable)
 

--- a/miopengemm/CMakeLists.txt
+++ b/miopengemm/CMakeLists.txt
@@ -15,7 +15,10 @@ file(GLOB_RECURSE source_files src/*.cpp)
 
 add_library(miopengemm ${source_files})
 
-target_link_libraries(miopengemm PUBLIC ${OPENCL_LIBRARIES} ${OpenBLAS_LIB} ${CLBLAST_LIB} ${ISAAC_LIB})
+# Adding opencl library as public is resulting in hard coded path for INTERFACE_LINK_LIBRARIES
+# So lmiting it to private, that will remove opencl from the interface link
+target_link_libraries(miopengemm PUBLIC  ${OpenBLAS_LIB} ${CLBLAST_LIB} ${ISAAC_LIB})
+target_link_libraries(miopengemm PRIVATE ${OPENCL_LIBRARIES})
 
 if(NOT WIN32 AND NOT APPLE)
     file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/lib.def "


### PR DESCRIPTION
Hard coded paths are not recommended in target config files.
Limited OpencL library as private while linking target libraries
Interface link libraries won't have any hard code paths.
Some examples directly used opencl, added opencl library path for building examples

Verified the smallgeometrytests and built the examples